### PR TITLE
Extract authro and PR from extras in markdown table

### DIFF
--- a/__tests__/markdown-parser.ts
+++ b/__tests__/markdown-parser.ts
@@ -27,30 +27,37 @@ describe("parse", () => {
       staging: [
         {
           name: "branch1",
+          author: "@yykamei",
+          pull: "#123",
           extras: {
-            branch: "branch1",
-            author: "@yykamei",
-            PR: "#123",
             Note: "This will be used until the end of October.",
           },
         },
         {
           name: "feature/add-something",
-          extras: { branch: "feature/add-something", author: "@yykamei", PR: "#138", Note: null },
+          author: "@yykamei",
+          pull: "#138",
+          extras: { Note: null },
         },
       ],
       strawberry: [
         {
           name: "feature/add-something",
-          extras: { Branch: "feature/add-something", author: "@yykamei", PR: "#138", Note: null },
+          author: "@yykamei",
+          pull: "#138",
+          extras: { Note: null },
         },
         {
           name: "branch2",
-          extras: { Branch: "branch2", author: "@yykamei", PR: "#139", Note: null },
+          author: "@yykamei",
+          pull: "#139",
+          extras: { Note: null },
         },
         {
           name: "branch3",
-          extras: { Branch: "branch3", author: "@yykamei", PR: "#140", Note: null },
+          author: "@yykamei",
+          pull: "#140",
+          extras: { Note: null },
         },
       ],
     })
@@ -70,11 +77,15 @@ Hi, it's staging branch.
       staging: [
         {
           name: "branch2",
-          extras: { branch: "branch2", author: "@yykamei", PR: "#993", Note: null },
+          author: "@yykamei",
+          pull: "#993",
+          extras: { Note: null },
         },
         {
           name: "branch3",
-          extras: { branch: "branch3", author: "@yykamei", PR: "#998", Note: null },
+          author: "@yykamei",
+          pull: "#998",
+          extras: { Note: null },
         },
       ],
     })
@@ -83,15 +94,17 @@ Hi, it's staging branch.
   it("parses the markdown body including the heading with strong and en", () => {
     const headingWithStrong = `
 ## <strong>feature</strong>/<en>fire</en>
-|branch|author|PR|Note|
-|-------|--------|--|-----|
-|branch4|@yykamei|#8|<p></p>|
+|branch|author|Note|
+|-------|--------|-----|
+|branch4|@yykamei|<p></p>|
 `
     expect(parse(headingWithStrong)).toEqual({
       "feature/fire": [
         {
           name: "branch4",
-          extras: { branch: "branch4", author: "@yykamei", PR: "#8", Note: null },
+          author: "@yykamei",
+          pull: null,
+          extras: { Note: null },
         },
       ],
     })

--- a/dist/index.js
+++ b/dist/index.js
@@ -19064,15 +19064,25 @@ const tableToTargetBranch = (node) => {
     core.debug(`We could get the headers with these values: ${headers}`);
     return rows.slice(1).map((row) => {
         let name = null;
+        let author = null;
+        let pull = null;
         const extras = {};
         row.forEach((v, idx) => {
-            var _a;
-            extras[headers[idx]] = v;
+            var _a, _b, _c;
             if (((_a = headers[idx]) === null || _a === void 0 ? void 0 : _a.toLowerCase()) === "branch") {
                 if (v == null) {
                     throw new Error("Branch must exist in the table row");
                 }
                 name = v;
+            }
+            else if (["author"].includes((_b = headers[idx]) === null || _b === void 0 ? void 0 : _b.toLowerCase())) {
+                author = v;
+            }
+            else if (["pr", "pull", "pull_request"].includes((_c = headers[idx]) === null || _c === void 0 ? void 0 : _c.toLowerCase())) {
+                pull = v;
+            }
+            else {
+                extras[headers[idx]] = v;
             }
         });
         if (name == null) {
@@ -19080,6 +19090,8 @@ const tableToTargetBranch = (node) => {
         }
         return {
             name,
+            author,
+            pull,
             extras,
         };
     });

--- a/src/markdown-parser.ts
+++ b/src/markdown-parser.ts
@@ -13,6 +13,8 @@ interface MergedBranches {
 
 interface TargetBranch {
   readonly name: string
+  readonly author: string | null
+  readonly pull: string | null
   readonly extras: {
     readonly [key: string]: string
   }
@@ -63,15 +65,22 @@ const tableToTargetBranch = (node: any): TargetBranch[] => {
 
   return rows.slice(1).map((row: any) => {
     let name: string | null = null
+    let author: string | null = null
+    let pull: string | null = null
     const extras: any = {}
 
     row.forEach((v: any, idx: number) => {
-      extras[headers[idx]] = v
       if (headers[idx]?.toLowerCase() === "branch") {
         if (v == null) {
           throw new Error("Branch must exist in the table row")
         }
         name = v
+      } else if (["author"].includes(headers[idx]?.toLowerCase())) {
+        author = v
+      } else if (["pr", "pull", "pull_request"].includes(headers[idx]?.toLowerCase())) {
+        pull = v
+      } else {
+        extras[headers[idx]] = v
       }
     })
     if (name == null) {
@@ -79,6 +88,8 @@ const tableToTargetBranch = (node: any): TargetBranch[] => {
     }
     return {
       name,
+      author,
+      pull,
       extras,
     }
   })


### PR DESCRIPTION
I'm considering making this tool modify the markdown table based on
issue comments. At this time, I want to add information on `author` and
`pull` headers automatically.