### PR TITLE
Rename the temporary script file name

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -19192,7 +19192,7 @@ const buildExec = ({ workingDirectory: cwd, shell }) => {
                     },
                 };
                 if (shell[0]) {
-                    const prefix = external_path_default().join(external_os_.tmpdir(), "before-merge");
+                    const prefix = external_path_default().join(external_os_.tmpdir(), "custom-");
                     const src = external_path_default().join(external_fs_.mkdtempSync(prefix), "script");
                     external_fs_.writeFileSync(src, source);
                     let exitCode = 0;

--- a/src/exec.ts
+++ b/src/exec.ts
@@ -68,7 +68,7 @@ export const buildExec = ({ workingDirectory: cwd, shell }: Params): Exec => {
       }
 
       if (shell[0]) {
-        const prefix = path.join(os.tmpdir(), "before-merge")
+        const prefix = path.join(os.tmpdir(), "custom-")
         const src = path.join(fs.mkdtempSync(prefix), "script")
         fs.writeFileSync(src, source)
         let exitCode = 0


### PR DESCRIPTION
`exec.ts` should not refer to the domain-specific name, such as `before`.