### PR TITLE
Check the existence of resetTarget

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -20706,7 +20706,13 @@ const deleteBranch = (target, { workingDirectory, shell, modifiedBranchSuffix })
 const prepare = ({ exec }, { force, baseBranch, targetBranches, modifiedBranchSuffix }) => git_awaiter(void 0, void 0, void 0, function* () {
     const run = (target, resetTarget) => git_awaiter(void 0, void 0, void 0, function* () {
         core.debug(`  checkout to ${target}...`);
-        yield exec("git", ["checkout", target]);
+        const { stdout: targetCheck } = yield exec("git", ["branch", "--remotes", "--list", `origin/${resetTarget}`]);
+        if (targetCheck.trim().length === 0) {
+            yield exec("git", ["checkout", "-b", resetTarget]);
+        }
+        else {
+            yield exec("git", ["checkout", resetTarget]);
+        }
         const { stdout } = yield exec("git", ["branch", "--remotes", "--list", `origin/${target}`]);
         if (stdout.trim().length === 0) {
             core.debug(`  creating ${target}...`);

--- a/src/git.ts
+++ b/src/git.ts
@@ -44,7 +44,13 @@ const prepare = async (
 ): Promise<void> => {
   const run = async (target: string, resetTarget: string) => {
     core.debug(`  checkout to ${target}...`)
-    await exec("git", ["checkout", target])
+
+    const { stdout: targetCheck } = await exec("git", ["branch", "--remotes", "--list", `origin/${resetTarget}`])
+    if (targetCheck.trim().length === 0) {
+      await exec("git", ["checkout", "-b", resetTarget])
+    } else {
+      await exec("git", ["checkout", resetTarget])
+    }
 
     const { stdout } = await exec("git", ["branch", "--remotes", "--list", `origin/${target}`])
     if (stdout.trim().length === 0) {


### PR DESCRIPTION
Each branch should be checked out with the original branch name.
This patch tries to check them beforehand.