### PR TITLE
Push resetTarget

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -20708,7 +20708,9 @@ const prepare = ({ exec }, { force, baseBranch, targetBranches, modifiedBranchSu
         core.debug(`  checkout to ${target}...`);
         const { stdout: targetCheck } = yield exec("git", ["branch", "--remotes", "--list", `origin/${resetTarget}`]);
         if (targetCheck.trim().length === 0) {
+            core.debug(`  creating ${resetTarget}...`);
             yield exec("git", ["checkout", "-b", resetTarget]);
+            yield exec("git", ["push", "origin", resetTarget]);
         }
         else {
             yield exec("git", ["checkout", resetTarget]);

--- a/src/git.ts
+++ b/src/git.ts
@@ -47,7 +47,9 @@ const prepare = async (
 
     const { stdout: targetCheck } = await exec("git", ["branch", "--remotes", "--list", `origin/${resetTarget}`])
     if (targetCheck.trim().length === 0) {
+      core.debug(`  creating ${resetTarget}...`)
       await exec("git", ["checkout", "-b", resetTarget])
+      await exec("git", ["push", "origin", resetTarget])
     } else {
       await exec("git", ["checkout", resetTarget])
     }


### PR DESCRIPTION
`run()` is also used for the `baseBranch`, so git-push(1) is required.

Follow-up of #39