### PR TITLE
Support issues event and reformat the issue body

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ on:
         required: false
         default: "false"
   delete:
+  issues:
+    types: [opened, edited, reopened]
 
 jobs:
   merge:

--- a/__tests__/run.ts
+++ b/__tests__/run.ts
@@ -133,6 +133,13 @@ describe("run", () => {
         "token"
       )
     })
+
+    it("does nothing because the issues number does not correspond to the inputs", async () => {
+      Object.defineProperty(context, "payload", {
+        value: { issue: { number: 89111 } },
+      })
+      await run()
+    })
   })
 
   describe("when the event is delete", () => {

--- a/__tests__/run.ts
+++ b/__tests__/run.ts
@@ -103,10 +103,35 @@ describe("run", () => {
   describe("when the event is issues", () => {
     beforeEach(() => {
       Object.defineProperty(context, "eventName", { value: "issues" })
+      Object.defineProperty(context, "payload", {
+        value: { issue: { number: 73 } },
+      })
     })
 
     it("succeeds", async () => {
+      const fetchData = jest.spyOn(github, "fetchData").mockResolvedValueOnce({
+        issue: {
+          id: "id!",
+          body: "## staging\n|branch|author|pr|!|\n|-|-|-|-|\n|b1||||\n",
+        },
+      } as any)
+      const updateIssue = jest.spyOn(github, "updateIssue").mockResolvedValueOnce(undefined)
       await run()
+      expect(fetchData).toHaveBeenCalledWith({ token: "token", issueNumber: 73 })
+      const newBody = `## staging
+
+| branch | author | pr | ! |
+| ------ | ------ | -- | - |
+| b1     |        |    |   |
+`
+      expect(updateIssue).toHaveBeenCalledWith(
+        {
+          id: "id!",
+          body: "## staging\n|branch|author|pr|!|\n|-|-|-|-|\n|b1||||\n",
+        },
+        newBody,
+        "token"
+      )
     })
   })
 

--- a/src/markdown-parser.ts
+++ b/src/markdown-parser.ts
@@ -55,6 +55,12 @@ export const parse = (body: string): Parsed => {
   return { node: result, mergedBranches }
 }
 
+export const reformat = (body: string): string => {
+  core.debug("Start reformat()")
+  const { node } = parse(body)
+  return unified().use(remarkGfm).use(remarkStringify).stringify(node)
+}
+
 export const remove = (body: string, branch: string): string => {
   core.debug("Start remove()")
   const parsed = parse(body)


### PR DESCRIPTION
This supports the `issues` event to reformat the issue body when someone
edits it. It would be difficult to make Markdown tables "beautiful" by
hand.

The users can use this feature by adding the `issues` event to their
workflow.