### PR TITLE
Do not merge upstream on baseBranch

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -20850,7 +20850,7 @@ const deleteBranch = (target, { workingDirectory, shell, modifiedBranchSuffix })
     yield exec.exec("git", ["push", "--delete", "origin", branch], {}, true);
 });
 const prepare = ({ exec }, { force, baseBranch, defaultBranch, targetBranches, modifiedBranchSuffix }) => git_awaiter(void 0, void 0, void 0, function* () {
-    const run = (target, resetTarget) => git_awaiter(void 0, void 0, void 0, function* () {
+    const run = (target, resetTarget, mergeUpstream = true) => git_awaiter(void 0, void 0, void 0, function* () {
         core.debug(`  checkout to ${target}...`);
         const { stdout: targetCheck } = yield exec("git", ["branch", "--remotes", "--list", `origin/${resetTarget}`]);
         if (targetCheck.trim().length === 0) {
@@ -20871,7 +20871,7 @@ const prepare = ({ exec }, { force, baseBranch, defaultBranch, targetBranches, m
             core.debug(`  checkout to ${target}...`);
             yield exec("git", ["checkout", target]);
         }
-        if (!force && target !== resetTarget) {
+        if (mergeUpstream && !force) {
             yield exec("git", ["merge", "--no-ff", "--no-edit", `origin/${resetTarget}`]);
         }
         if (force) {
@@ -20884,7 +20884,7 @@ const prepare = ({ exec }, { force, baseBranch, defaultBranch, targetBranches, m
     for (const target of targetBranches) {
         yield run(modifiedBranch(target, modifiedBranchSuffix), target);
     }
-    yield run(baseBranch, defaultBranch);
+    yield run(baseBranch, defaultBranch, false);
     core.debug("Finish prepare()");
 });
 const configureGit = ({ exec }) => git_awaiter(void 0, void 0, void 0, function* () {

--- a/src/git.ts
+++ b/src/git.ts
@@ -42,7 +42,7 @@ const prepare = async (
   { exec }: Exec,
   { force, baseBranch, defaultBranch, targetBranches, modifiedBranchSuffix }: Params
 ): Promise<void> => {
-  const run = async (target: string, resetTarget: string, mergeUpstream: boolean = true) => {
+  const run = async (target: string, resetTarget: string, mergeUpstream = true) => {
     core.debug(`  checkout to ${target}...`)
 
     const { stdout: targetCheck } = await exec("git", ["branch", "--remotes", "--list", `origin/${resetTarget}`])

--- a/src/git.ts
+++ b/src/git.ts
@@ -42,7 +42,7 @@ const prepare = async (
   { exec }: Exec,
   { force, baseBranch, defaultBranch, targetBranches, modifiedBranchSuffix }: Params
 ): Promise<void> => {
-  const run = async (target: string, resetTarget: string) => {
+  const run = async (target: string, resetTarget: string, mergeUpstream: boolean = true) => {
     core.debug(`  checkout to ${target}...`)
 
     const { stdout: targetCheck } = await exec("git", ["branch", "--remotes", "--list", `origin/${resetTarget}`])
@@ -64,7 +64,7 @@ const prepare = async (
       await exec("git", ["checkout", target])
     }
 
-    if (!force && target !== resetTarget) {
+    if (mergeUpstream && !force) {
       await exec("git", ["merge", "--no-ff", "--no-edit", `origin/${resetTarget}`])
     }
 
@@ -79,7 +79,7 @@ const prepare = async (
   for (const target of targetBranches) {
     await run(modifiedBranch(target, modifiedBranchSuffix), target)
   }
-  await run(baseBranch, defaultBranch)
+  await run(baseBranch, defaultBranch, false)
   core.debug("Finish prepare()")
 }
 


### PR DESCRIPTION
`baseBranch` should not include the upstream branch without a force option.