### PR TITLE
Add git-branch(1) with -D in the conflict navigate

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -20934,6 +20934,7 @@ ${diff}
 You might be able to resolve conflicts on your local machine 💻 with these commands:
 
 git fetch
+git branch -D ${baseBranch}
 git checkout ${baseBranch}
 git pull origin ${baseBranch}
 git merge --no-ff origin/${branch}

--- a/src/git.ts
+++ b/src/git.ts
@@ -140,6 +140,7 @@ ${diff}
 You might be able to resolve conflicts on your local machine 💻 with these commands:
 
 git fetch
+git branch -D ${baseBranch}
 git checkout ${baseBranch}
 git pull origin ${baseBranch}
 git merge --no-ff origin/${branch}


### PR DESCRIPTION
Fix #72 

If the `baseBranch` already exists, git-pull(1) with fast-forward won't work, so I want to add git-branch(1) with -D in the navigation to ensure the `baseBranch` does not exist in the local environment.