### PR TITLE
Fix mergeTarget to checkout beforehand

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -20888,6 +20888,7 @@ const runAfterMerge = ({ exec, script }, { baseBranch, afterMerge }) => git_awai
     }
 });
 const mergeTargets = ({ exec }, { defaultBranch, baseBranch, targetBranches, modifiedBranchSuffix }) => git_awaiter(void 0, void 0, void 0, function* () {
+    yield exec("git", ["checkout", baseBranch]);
     for (const target of targetBranches) {
         const branch = modifiedBranch(target, modifiedBranchSuffix);
         const { exitCode } = yield exec("git", ["merge", "--no-ff", "--no-edit", branch], {}, true);

--- a/src/git.ts
+++ b/src/git.ts
@@ -101,6 +101,7 @@ const mergeTargets = async (
   { exec }: Exec,
   { defaultBranch, baseBranch, targetBranches, modifiedBranchSuffix }: Params
 ) => {
+  await exec("git", ["checkout", baseBranch])
   for (const target of targetBranches) {
     const branch = modifiedBranch(target, modifiedBranchSuffix)
     const { exitCode } = await exec("git", ["merge", "--no-ff", "--no-edit", branch], {}, true)


### PR DESCRIPTION
`mergeTargets` must checkout to `baseBranch` beforehand.