### PR TITLE
Update README.md to add concurrency

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ After creating an issue, configure this tool with the following workflow:
 
 ```yaml
 name: Merge Branches Managed on Issue
+concurrency: merge_branches # This might be required to prevent multiple jobs from running  at the same time
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
During merging branches into a base branch, this action should not run other workflows triggered by another member because working branches might be pushed by other workflows; it causes significant errors.