### PR TITLE
Suffix baseBranch to modified branches

### DIFF
--- a/__tests__/run.ts
+++ b/__tests__/run.ts
@@ -307,6 +307,7 @@ describe("run", () => {
         workingDirectory: "/foo",
         shell: ["bash", "-eo", "pipefail"],
         modifiedBranchSuffix: ".modified",
+        baseBranch: "base-branch",
       })
       const newBody = `This is a markdown body.
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -21006,7 +21006,7 @@ const merge = (params) => git_awaiter(void 0, void 0, void 0, function* () {
     yield pushBaseBranch(exec, params);
     return yield output(exec, params);
 });
-const deleteBranch = (target, { workingDirectory, shell, modifiedBranchSuffix, baseBranch }) => git_awaiter(void 0, void 0, void 0, function* () {
+const deleteBranch = (target, { workingDirectory, shell, modifiedBranchSuffix, baseBranch, }) => git_awaiter(void 0, void 0, void 0, function* () {
     const exec = buildExec({ workingDirectory, shell });
     const branch = modifiedBranch(target, modifiedBranchSuffix, baseBranch);
     const oldBranch = oldModifiedBranch(target, modifiedBranchSuffix);

--- a/dist/index.js
+++ b/dist/index.js
@@ -20997,8 +20997,8 @@ const merge = (params) => git_awaiter(void 0, void 0, void 0, function* () {
     yield configureGit(exec);
     yield prepareBranch(exec, baseBranch, defaultBranch, force);
     for (const target of targetBranches) {
-        yield prepareBranch(exec, modifiedBranch(target, modifiedBranchSuffix), target, force);
-        yield mergeUpstream(exec, modifiedBranch(target, modifiedBranchSuffix), target, beforeMerge);
+        yield prepareBranch(exec, modifiedBranch(target, modifiedBranchSuffix, baseBranch), target, force);
+        yield mergeUpstream(exec, modifiedBranch(target, modifiedBranchSuffix, baseBranch), target, beforeMerge);
     }
     yield runBeforeMerge(exec, params);
     yield mergeTargets(exec, params);
@@ -21006,10 +21006,12 @@ const merge = (params) => git_awaiter(void 0, void 0, void 0, function* () {
     yield pushBaseBranch(exec, params);
     return yield output(exec, params);
 });
-const deleteBranch = (target, { workingDirectory, shell, modifiedBranchSuffix }) => git_awaiter(void 0, void 0, void 0, function* () {
-    const branch = modifiedBranch(target, modifiedBranchSuffix);
+const deleteBranch = (target, { workingDirectory, shell, modifiedBranchSuffix, baseBranch }) => git_awaiter(void 0, void 0, void 0, function* () {
     const exec = buildExec({ workingDirectory, shell });
+    const branch = modifiedBranch(target, modifiedBranchSuffix, baseBranch);
+    const oldBranch = oldModifiedBranch(target, modifiedBranchSuffix);
     yield exec.exec("git", ["push", "--delete", "origin", branch], {}, true);
+    yield exec.exec("git", ["push", "--delete", "origin", oldBranch], {}, true);
 });
 const configureGit = ({ exec }) => git_awaiter(void 0, void 0, void 0, function* () {
     // TODO: `name` and `email` should be configurable.
@@ -21067,7 +21069,7 @@ const runAfterMerge = ({ exec, script }, { baseBranch, afterMerge }) => git_awai
 const mergeTargets = ({ exec }, { defaultBranch, baseBranch, targetBranches, modifiedBranchSuffix }) => git_awaiter(void 0, void 0, void 0, function* () {
     yield exec("git", ["checkout", baseBranch]);
     for (const target of targetBranches) {
-        const branch = modifiedBranch(target, modifiedBranchSuffix);
+        const branch = modifiedBranch(target, modifiedBranchSuffix, baseBranch);
         const { exitCode } = yield exec("git", ["merge", "--no-ff", "--no-edit", branch], {}, true);
         if (exitCode !== 0) {
             const { stdout: status } = yield exec("git", ["status"], {}, true);
@@ -21106,7 +21108,8 @@ const output = ({ exec }, { defaultBranch }) => git_awaiter(void 0, void 0, void
     const { stdout } = yield exec("git", ["log", "--merges", "--oneline", `origin/${defaultBranch}...HEAD`]);
     return stdout;
 });
-const modifiedBranch = (branch, modifiedBranchSuffix) => `${branch}${modifiedBranchSuffix}`;
+const oldModifiedBranch = (branch, modifiedBranchSuffix) => `${branch}${modifiedBranchSuffix}`;
+const modifiedBranch = (branch, modifiedBranchSuffix, baseBranch) => `${branch}${modifiedBranchSuffix}-${baseBranch}`;
 
 ;// CONCATENATED MODULE: ./src/run.ts
 var run_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arguments, P, generator) {
@@ -21210,14 +21213,14 @@ const handleIssueComment = ({ token, issueNumber, commentPrefix }) => run_awaite
         throw e;
     }
 });
-const handleDelete = ({ token, issueNumber, workingDirectory, shell, modifiedBranchSuffix }) => run_awaiter(void 0, void 0, void 0, function* () {
+const handleDelete = ({ token, issueNumber, workingDirectory, shell, inputsParamBaseBranch, modifiedBranchSuffix, }) => run_awaiter(void 0, void 0, void 0, function* () {
     const payload = github.context.payload;
     if (payload.ref_type !== "branch") {
         return;
     }
     const branch = payload.ref.replace("refs/heads/", "");
     const { issue } = yield fetchData({ token, issueNumber });
-    yield deleteBranch(branch, { workingDirectory, shell, modifiedBranchSuffix });
+    yield deleteBranch(branch, { workingDirectory, shell, modifiedBranchSuffix, baseBranch: inputsParamBaseBranch });
     const newBody = remove(issue.body, branch);
     yield updateIssue(issue, newBody, token);
 });

--- a/src/git.ts
+++ b/src/git.ts
@@ -31,8 +31,8 @@ export const merge = async (params: Params): Promise<string> => {
   await configureGit(exec)
   await prepareBranch(exec, baseBranch, defaultBranch, force)
   for (const target of targetBranches) {
-    await prepareBranch(exec, modifiedBranch(target, modifiedBranchSuffix), target, force)
-    await mergeUpstream(exec, modifiedBranch(target, modifiedBranchSuffix), target, beforeMerge)
+    await prepareBranch(exec, modifiedBranch(target, modifiedBranchSuffix, baseBranch), target, force)
+    await mergeUpstream(exec, modifiedBranch(target, modifiedBranchSuffix, baseBranch), target, beforeMerge)
   }
 
   await runBeforeMerge(exec, params)
@@ -45,11 +45,13 @@ export const merge = async (params: Params): Promise<string> => {
 
 export const deleteBranch = async (
   target: string,
-  { workingDirectory, shell, modifiedBranchSuffix }: Pick<Params, "workingDirectory" | "shell" | "modifiedBranchSuffix">
+  { workingDirectory, shell, modifiedBranchSuffix, baseBranch }: Pick<Params, "workingDirectory" | "shell" | "modifiedBranchSuffix" | "baseBranch">
 ): Promise<void> => {
-  const branch = modifiedBranch(target, modifiedBranchSuffix)
   const exec = buildExec({ workingDirectory, shell })
+  const branch = modifiedBranch(target, modifiedBranchSuffix, baseBranch)
+  const oldBranch = oldModifiedBranch(target, modifiedBranchSuffix)
   await exec.exec("git", ["push", "--delete", "origin", branch], {}, true)
+  await exec.exec("git", ["push", "--delete", "origin", oldBranch], {}, true)
 }
 
 const configureGit = async ({ exec }: Exec): Promise<void> => {
@@ -124,7 +126,7 @@ const mergeTargets = async (
 ) => {
   await exec("git", ["checkout", baseBranch])
   for (const target of targetBranches) {
-    const branch = modifiedBranch(target, modifiedBranchSuffix)
+    const branch = modifiedBranch(target, modifiedBranchSuffix, baseBranch)
     const { exitCode } = await exec("git", ["merge", "--no-ff", "--no-edit", branch], {}, true)
     if (exitCode !== 0) {
       const { stdout: status } = await exec("git", ["status"], {}, true)
@@ -166,4 +168,7 @@ const output = async ({ exec }: Exec, { defaultBranch }: Params): Promise<string
   return stdout
 }
 
-const modifiedBranch = (branch: string, modifiedBranchSuffix: string): string => `${branch}${modifiedBranchSuffix}`
+const oldModifiedBranch = (branch: string, modifiedBranchSuffix: string): string => `${branch}${modifiedBranchSuffix}`
+
+const modifiedBranch = (branch: string, modifiedBranchSuffix: string, baseBranch: string): string =>
+  `${branch}${modifiedBranchSuffix}-${baseBranch}`

--- a/src/git.ts
+++ b/src/git.ts
@@ -45,7 +45,12 @@ export const merge = async (params: Params): Promise<string> => {
 
 export const deleteBranch = async (
   target: string,
-  { workingDirectory, shell, modifiedBranchSuffix, baseBranch }: Pick<Params, "workingDirectory" | "shell" | "modifiedBranchSuffix" | "baseBranch">
+  {
+    workingDirectory,
+    shell,
+    modifiedBranchSuffix,
+    baseBranch,
+  }: Pick<Params, "workingDirectory" | "shell" | "modifiedBranchSuffix" | "baseBranch">
 ): Promise<void> => {
   const exec = buildExec({ workingDirectory, shell })
   const branch = modifiedBranch(target, modifiedBranchSuffix, baseBranch)

--- a/src/run.ts
+++ b/src/run.ts
@@ -123,14 +123,21 @@ const handleIssueComment = async ({ token, issueNumber, commentPrefix }: Inputs)
   }
 }
 
-const handleDelete = async ({ token, issueNumber, workingDirectory, shell, modifiedBranchSuffix }: Inputs) => {
+const handleDelete = async ({
+  token,
+  issueNumber,
+  workingDirectory,
+  shell,
+  inputsParamBaseBranch,
+  modifiedBranchSuffix,
+}: Inputs) => {
   const payload = context.payload as DeleteEvent
   if (payload.ref_type !== "branch") {
     return
   }
   const branch = payload.ref.replace("refs/heads/", "")
   const { issue } = await fetchData({ token, issueNumber })
-  await deleteBranch(branch, { workingDirectory, shell, modifiedBranchSuffix })
+  await deleteBranch(branch, { workingDirectory, shell, modifiedBranchSuffix, baseBranch: inputsParamBaseBranch })
   const newBody = remove(issue.body, branch)
   await updateIssue(issue, newBody, token)
 }


### PR DESCRIPTION
If a user manages multiple `baseBranch`s, it would be better to manage "modified" branches respectively.

## Breaking changes

I think this pull request includes breaking changes because "modified" branch names will be changed. Especially, `deleteBranch` could be affected by this change, but I tried to have it delete the "old modified" branch named as possible.
