### PR TITLE
Fix deleteBranches to delete all modified branches

### DIFF
--- a/__tests__/run.ts
+++ b/__tests__/run.ts
@@ -307,7 +307,7 @@ describe("run", () => {
         workingDirectory: "/foo",
         shell: ["bash", "-eo", "pipefail"],
         modifiedBranchSuffix: ".modified",
-        baseBranch: "base-branch",
+        baseBranches: ["staging", "strawberry"],
       })
       const newBody = `This is a markdown body.
 

--- a/src/git.ts
+++ b/src/git.ts
@@ -49,14 +49,16 @@ export const deleteBranch = async (
     workingDirectory,
     shell,
     modifiedBranchSuffix,
-    baseBranch,
-  }: Pick<Params, "workingDirectory" | "shell" | "modifiedBranchSuffix" | "baseBranch">
+    baseBranches,
+  }: Pick<Params, "workingDirectory" | "shell" | "modifiedBranchSuffix"> & { readonly baseBranches: string[] }
 ): Promise<void> => {
   const exec = buildExec({ workingDirectory, shell })
-  const branch = modifiedBranch(target, modifiedBranchSuffix, baseBranch)
   const oldBranch = oldModifiedBranch(target, modifiedBranchSuffix)
-  await exec.exec("git", ["push", "--delete", "origin", branch], {}, true)
   await exec.exec("git", ["push", "--delete", "origin", oldBranch], {}, true)
+  for (const baseBranch of baseBranches) {
+    const branch = modifiedBranch(target, modifiedBranchSuffix, baseBranch)
+    await exec.exec("git", ["push", "--delete", "origin", branch], {}, true)
+  }
 }
 
 const configureGit = async ({ exec }: Exec): Promise<void> => {

--- a/src/run.ts
+++ b/src/run.ts
@@ -123,21 +123,16 @@ const handleIssueComment = async ({ token, issueNumber, commentPrefix }: Inputs)
   }
 }
 
-const handleDelete = async ({
-  token,
-  issueNumber,
-  workingDirectory,
-  shell,
-  inputsParamBaseBranch,
-  modifiedBranchSuffix,
-}: Inputs) => {
+const handleDelete = async ({ token, issueNumber, workingDirectory, shell, modifiedBranchSuffix }: Inputs) => {
   const payload = context.payload as DeleteEvent
   if (payload.ref_type !== "branch") {
     return
   }
   const branch = payload.ref.replace("refs/heads/", "")
   const { issue } = await fetchData({ token, issueNumber })
-  await deleteBranch(branch, { workingDirectory, shell, modifiedBranchSuffix, baseBranch: inputsParamBaseBranch })
+  const result = parse(issue.body).mergedBranches
+  const baseBranches = Object.keys(result)
+  await deleteBranch(branch, { workingDirectory, shell, modifiedBranchSuffix, baseBranches })
   const newBody = remove(issue.body, branch)
   await updateIssue(issue, newBody, token)
 }


### PR DESCRIPTION
#198 did nothing because it depended on `inputs`of workflow, but `deleteBranches` is not triggered by workflow dispatch.