### PR TITLE
Add ignore option to action.yml

### DIFF
--- a/__tests__/inputs.ts
+++ b/__tests__/inputs.ts
@@ -16,6 +16,7 @@ describe("getInputs", () => {
           "before-merge": `echo OK
 ls -al
 date`,
+          ignore: "example/",
         })[name] as any,
     )
   })
@@ -32,6 +33,7 @@ date`,
     expect(inputs.inputsParamForce).toStrictEqual("force")
     expect(inputs.modifiedBranchSuffix).toStrictEqual(".modified")
     expect(inputs.commentPrefix).toStrictEqual("/mbmi")
+    expect(inputs.ignore).toStrictEqual("example/")
   })
 
   it("calls getInput()", () => {
@@ -46,6 +48,7 @@ date`,
     expect(getInput).toHaveBeenCalledWith("inputs-param-force")
     expect(getInput).toHaveBeenCalledWith("modified-branch-suffix")
     expect(getInput).toHaveBeenCalledWith("comment-prefix")
+    expect(getInput).toHaveBeenCalledWith("ignore")
   })
 
   describe("when before-merge is not set", () => {

--- a/__tests__/run.ts
+++ b/__tests__/run.ts
@@ -63,6 +63,7 @@ describe("run", () => {
         modifiedBranchSuffix: ".modified",
         defaultBranch: "main",
         force: false,
+        ignore: null,
       })
     })
 

--- a/__tests__/run.ts
+++ b/__tests__/run.ts
@@ -19,6 +19,7 @@ describe("run", () => {
       inputsParamForce: "force",
       modifiedBranchSuffix: ".modified",
       commentPrefix: "/mbmi",
+      ignore: null,
     }))
   })
 

--- a/action.yml
+++ b/action.yml
@@ -32,6 +32,9 @@ inputs:
     description: The GitHub token used to create an authenticated client
     required: false
     default: ${{ github.token }}
+  ignore:
+    description: The list of files or directories to ignore.example) "example/, example.txt"
+    required: false
 branding:
   icon: git-merge
   color: red

--- a/dist/index.js
+++ b/dist/index.js
@@ -44520,7 +44520,7 @@ const merge = (params) => git_awaiter(void 0, void 0, void 0, function* () {
     yield prepareBranch(exec, baseBranch, defaultBranch, force, ignore);
     for (const target of targetBranches) {
         yield prepareBranch(exec, modifiedBranch(target, modifiedBranchSuffix, baseBranch), target, force, ignore);
-        yield mergeUpstream(exec, modifiedBranch(target, modifiedBranchSuffix, baseBranch), target, beforeMerge);
+        yield mergeUpstream(exec, modifiedBranch(target, modifiedBranchSuffix, baseBranch), target, beforeMerge, ignore);
     }
     yield runBeforeMerge(exec, params);
     yield mergeTargets(exec, params);
@@ -44546,7 +44546,7 @@ const prepareBranch = ({ exec }, dest, src, force, ignore) => git_awaiter(void 0
     const { stdout: targetCheck } = yield exec("git", ["branch", "--remotes", "--list", `origin/${dest}`]);
     if (targetCheck.trim().length === 0) {
         yield exec("git", ["checkout", "-b", dest, `origin/${src}`]);
-        if (ignore) {
+        if (ignore != null) {
           yield exec("git", ["rm", "-r", ignore])
           yield exec("git", ["add", "."])
           yield exec("git", ["commit", "-m", "Delete ignore_files"])
@@ -44561,7 +44561,7 @@ const prepareBranch = ({ exec }, dest, src, force, ignore) => git_awaiter(void 0
         yield exec("git", ["push", "--force", "origin", dest]);
     }
 });
-const mergeUpstream = ({ exec, script }, dest, src, beforeMerge) => git_awaiter(void 0, void 0, void 0, function* () {
+const mergeUpstream = ({ exec, script }, dest, src, beforeMerge, ignore) => git_awaiter(void 0, void 0, void 0, function* () {
     yield exec("git", ["checkout", src]);
     if (beforeMerge != null) {
         yield script(beforeMerge, { CURRENT_BRANCH: src, BASE_BRANCH: src });
@@ -44577,6 +44577,11 @@ const mergeUpstream = ({ exec, script }, dest, src, beforeMerge) => git_awaiter(
         yield exec("git", ["checkout", src]);
         yield exec("git", ["branch", "-D", dest]);
         yield exec("git", ["checkout", "-b", dest]);
+        if (ignore != null) {
+          yield exec("git", ["rm", "-r", ignore])
+          yield exec("git", ["add", "."])
+          yield exec("git", ["commit", "-m", "Delete ignore_files"])
+        }
         yield exec("git", ["push", "--force", "origin", dest]);
     }
     else {

--- a/dist/index.js
+++ b/dist/index.js
@@ -44547,9 +44547,9 @@ const prepareBranch = ({ exec }, dest, src, force, ignore) => git_awaiter(void 0
     if (targetCheck.trim().length === 0) {
         yield exec("git", ["checkout", "-b", dest, `origin/${src}`]);
         if (ignore != null) {
-            exec("git", ["rm", "-r", ignore]);
-            exec("git", ["add", "."]);
-            exec("git", ["commit", "-m", "Delete ignore_files"]);
+            yield exec("git", ["rm", "-r", ignore]);
+            yield exec("git", ["add", "."]);
+            yield exec("git", ["commit", "-m", "Delete ignore_files"]);
         }
         yield exec("git", ["push", "origin", dest]);
     }
@@ -44578,9 +44578,9 @@ const mergeUpstream = ({ exec, script }, dest, src, beforeMerge, ignore) => git_
         yield exec("git", ["branch", "-D", dest]);
         yield exec("git", ["checkout", "-b", dest]);
         if (ignore != null) {
-            exec("git", ["rm", "-r", ignore]);
-            exec("git", ["add", "."]);
-            exec("git", ["commit", "-m", "Delete ignore_files"]);
+            yield exec("git", ["rm", "-r", ignore]);
+            yield exec("git", ["add", "."]);
+            yield exec("git", ["commit", "-m", "Delete ignore_files"]);
         }
         yield exec("git", ["push", "--force", "origin", dest]);
     }

--- a/dist/index.js
+++ b/dist/index.js
@@ -44677,7 +44677,7 @@ const run = () => run_awaiter(void 0, void 0, void 0, function* () {
             throw new Error(`This action does not support the event "${github.context.eventName}"`);
     }
 });
-const handleWorkflowDispatch = ({ token, issueNumber, workingDirectory, shell, beforeMerge, afterMerge, inputsParamBaseBranch, inputsParamForce, modifiedBranchSuffix, }) => run_awaiter(void 0, void 0, void 0, function* () {
+const handleWorkflowDispatch = ({ token, issueNumber, workingDirectory, shell, beforeMerge, afterMerge, inputsParamBaseBranch, inputsParamForce, modifiedBranchSuffix, ignore, }) => run_awaiter(void 0, void 0, void 0, function* () {
     const payload = github.context.payload;
     core.debug(`We got the workflow_dispatch event with this payload: ${payload}.`);
     if (payload.inputs == null || !(inputsParamBaseBranch in payload.inputs) || !(inputsParamForce in payload.inputs)) {
@@ -44701,6 +44701,7 @@ const handleWorkflowDispatch = ({ token, issueNumber, workingDirectory, shell, b
         modifiedBranchSuffix,
         defaultBranch,
         force,
+        ignore,
     });
 });
 const handleIssues = ({ issueNumber, token }) => run_awaiter(void 0, void 0, void 0, function* () {

--- a/src/git.ts
+++ b/src/git.ts
@@ -80,9 +80,9 @@ const prepareBranch = async (
   if (targetCheck.trim().length === 0) {
     await exec("git", ["checkout", "-b", dest, `origin/${src}`])
     if (ignore != null) {
-      exec("git", ["rm", "-r", ignore])
-      exec("git", ["add", "."])
-      exec("git", ["commit", "-m", "Delete ignore_files"])
+      await exec("git", ["rm", "-r", ignore])
+      await exec("git", ["add", "."])
+      await exec("git", ["commit", "-m", "Delete ignore_files"])
     }
     await exec("git", ["push", "origin", dest])
   } else {
@@ -122,9 +122,9 @@ const mergeUpstream = async (
     await exec("git", ["branch", "-D", dest])
     await exec("git", ["checkout", "-b", dest])
     if (ignore != null) {
-      exec("git", ["rm", "-r", ignore])
-      exec("git", ["add", "."])
-      exec("git", ["commit", "-m", "Delete ignore_files"])
+      await exec("git", ["rm", "-r", ignore])
+      await exec("git", ["add", "."])
+      await exec("git", ["commit", "-m", "Delete ignore_files"])
     }
     await exec("git", ["push", "--force", "origin", dest])
   } else {

--- a/src/inputs.ts
+++ b/src/inputs.ts
@@ -12,6 +12,7 @@ export interface Inputs {
   readonly inputsParamForce: string
   readonly modifiedBranchSuffix: string
   readonly commentPrefix: string
+  readonly ignore: string | null
 }
 
 export const getInputs = (): Inputs => {
@@ -26,6 +27,7 @@ export const getInputs = (): Inputs => {
     inputsParamForce: getInput("inputs-param-force") || "force", // NOTE: Make the value `null` if it seems falsy.
     modifiedBranchSuffix: getInput("modified-branch-suffix") || ".modified", // NOTE: Make the value `null` if it seems falsy.
     commentPrefix: getInput("comment-prefix") || "/mbmi", // NOTE: Make the value `null` if it seems falsy.
+    ignore: getInput("ignore") || null, // NOTE: Make the value `null` if it seems falsy.
   }
 }
 

--- a/src/run.ts
+++ b/src/run.ts
@@ -35,6 +35,7 @@ const handleWorkflowDispatch = async ({
   inputsParamBaseBranch,
   inputsParamForce,
   modifiedBranchSuffix,
+  ignore,
 }: Inputs) => {
   const payload = context.payload as WorkflowDispatchEvent
   core.debug(`We got the workflow_dispatch event with this payload: ${payload}.`)
@@ -65,6 +66,7 @@ const handleWorkflowDispatch = async ({
     modifiedBranchSuffix,
     defaultBranch,
     force,
+    ignore,
   })
 }
 


### PR DESCRIPTION
When executing merge branches, unnecessary files are also merged, which can lead to frequent conflicts. For example, test code may not be necessary in the staging environment, so we would like to exclude it from the merge process. Therefore, we have added an option to delete unnecessary files when creating a branch for merging.