### PR TITLE
Use Node.js v22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: ["20"]
+        node: ["20", "22"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
           check-latest: true
           cache: npm
 


### PR DESCRIPTION
This pull request includes updates to the Node.js versions used in the CI and release workflows to ensure compatibility with newer versions.

Updates to CI and release workflows:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL13-R13): Added Node.js version 22 to the matrix strategy.
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L26-R26): Updated the Node.js version to 22.


Node.js v22 is [available](https://nodejs.org/en/blog/announcements/v22-release-announce), and now it's [entered](https://nodejs.org/en/blog/release/v22.11.0) Long Term Support (LTS).

I think it's time to use it in this repository CI.